### PR TITLE
AA-657 Consume ng-eid Lab Order Viewer From ng-amrs

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -148,7 +148,8 @@
     <script src="bower_components/flot/jquery.flot.js"></script>
     <script src="bower_components/holderjs/holder.js"></script>
     <script src="bower_components/metisMenu/dist/metisMenu.js"></script>
-    <script src="bower_components/raphael/raphael.js"></script>
+    <script src="bower_components/eve/eve.js"></script>
+    <script src="bower_components/raphael/raphael.min.js"></script>
     <script src="bower_components/mocha/mocha.js"></script>
     <script src="bower_components/morrisjs/morris.js"></script>
     <script src="bower_components/datatables-responsive/js/dataTables.responsive.js"></script>
@@ -164,6 +165,7 @@
     <script src="bower_components/angular-bar-code-scanner/angular-bar-code-scanner.min.js"></script>
     <script src="bower_components/keen-js/dist/keen.min.js"></script>
     <script src="bower_components/c3-angular/c3-angular.min.js"></script>
+    <script src="bower_components/ng-eid/dist/scripts/ng-eid.js"></script>
     <!-- endbower -->
     <!-- endbuild -->
 

--- a/app/scripts/patient-dashboard/controllers/patient-dashboard.controller.js
+++ b/app/scripts/patient-dashboard/controllers/patient-dashboard.controller.js
@@ -17,6 +17,13 @@
   function PatientDashboardCtrl($rootScope, $scope, $stateParams, $timeout, OpenmrsRestService, ClinicalSummaryPdfService) {
     $scope.patient = {};
     $scope.patient = $rootScope.broadcastPatient;
+    if($scope.patient) $scope.patientIdentifiers = [
+      $scope.patient.commonIdentifiers().ampathMrsUId||'',
+      $scope.patient.commonIdentifiers().amrsMrn||'',
+      $scope.patient.commonIdentifiers().cCC||'',
+      $scope.patient.commonIdentifiers().kenyaNationalId||''
+    ];
+
     $scope.p = null;
     $scope.encounters = [];
     $scope.isBusy=false;

--- a/app/scripts/patient-dashboard/patient-dashboard.module.js
+++ b/app/scripts/patient-dashboard/patient-dashboard.module.js
@@ -6,6 +6,7 @@
             'app.openmrsRestServices',
             'app.etlRestServices',
             'dialogs.main',
-            'kendo.directives'
+            'kendo.directives',
+            'app.eid'
         ]);
 })();

--- a/app/views/patient-dashboard/patient-dashboard.html
+++ b/app/views/patient-dashboard/patient-dashboard.html
@@ -54,6 +54,9 @@
 				<li active-tab-sync index="5" data-ng-glick="activeList(this, 5)" ng-class="{active: activeListId === 5}">
 					<a data-target="#tab5" data-toggle="tab"><span class="icon-i-laboratory" aria-hidden="true"></span>&nbsp;Lab Data Summary</a>
 				</li>
+        <li active-tab-sync index="11" data-ng-glick="activeList(this, 11)" ng-class="{active: activeListId === 11}">
+          <a data-target="#tab11" data-toggle="tab"><span class="icon-i-laboratory" aria-hidden="true"></span>&nbsp;EID Lab Data Summary</a>
+        </li>
 				<li active-tab-sync index="6" data-ng-glick="activeList(this, 6)" ng-class="{active: activeListId === 6}">
 					<a data-target="#tab6" data-toggle="tab"><span class="glyphicon glyphicon-tasks" aria-hidden="true"></span>&nbsp;Current Visit</a>
 				</li>
@@ -83,6 +86,9 @@
 				<li active-tab-sync index="5" data-ng-glick="activeList(this, 5)" ng-class="{active: activeListId === 5}">
 					<a data-target="#tab5" data-toggle="tab"><span class="icon-i-laboratory" aria-hidden="true"></span>&nbsp;Lab Data Summary</a>
 				</li>
+        <li active-tab-sync index="11" data-ng-glick="activeList(this, 11)" ng-class="{active: activeListId === 11}">
+          <a data-target="#tab11" data-toggle="tab"><span class="icon-i-laboratory" aria-hidden="true"></span>&nbsp;EID Lab Data Summary</a>
+        </li>
 				<li active-tab-sync index="6" data-ng-glick="activeList(this, 6)" ng-class="{active: activeListId === 6}">
 					<a data-target="#tab6" data-toggle="tab"><span class="glyphicon glyphicon-tasks" aria-hidden="true"></span>&nbsp;Current Visit</a>
 				</li>
@@ -131,6 +137,11 @@
 					<labs-summary patient-uuid="{{patient.uuid()}}" encounters="labTests" is-busy="labTestsIsBusy"></labs-summary>
 				</div>
 			</div>
+      <div class="tab-pane fade in panel panel-default  " style="padding:4px;" id="tab11">
+        <div class="page-content">
+          <eid-lab-tests patient-identifiers="patientIdentifiers"></eid-lab-tests >
+        </div>
+      </div>
 			<div class="tab-pane fade in panel panel-default  " style="padding:4px;" id="tab6">
 				<div class="page-content">
 					<current-visit patient-uuid="{{patient.uuid()}}"></current-visit>

--- a/bower.json
+++ b/bower.json
@@ -48,7 +48,8 @@
     "angular-cache": "^4.5.0",
     "angular-bar-code-scanner": "~1.0.0",
     "keen-js": "^3.4.0",
-    "c3-angular": "^1.2.0"
+    "c3-angular": "^1.2.0",
+    "ng-eid": "https://github.com/kimaina/ng-eid.git#^0.0.4"
   },
   "devDependencies": {
     "angular-mocks": "^1.3.0"

--- a/test/karma.conf.js
+++ b/test/karma.conf.js
@@ -82,7 +82,8 @@ module.exports = function (config) {
     'bower_components/flot/jquery.flot.js',
     'bower_components/holderjs/holder.js',
     'bower_components/metisMenu/dist/metisMenu.js',
-    'bower_components/raphael/raphael.js',
+    'bower_components/eve/eve.js',
+    'bower_components/raphael/raphael.min.js',
     'bower_components/mocha/mocha.js',
     'bower_components/morrisjs/morris.js',
     'bower_components/datatables-responsive/js/dataTables.responsive.js',
@@ -98,6 +99,7 @@ module.exports = function (config) {
     'bower_components/angular-bar-code-scanner/angular-bar-code-scanner.min.js',
     'bower_components/keen-js/dist/keen.min.js',
     'bower_components/c3-angular/c3-angular.min.js',
+    'bower_components/ng-eid/dist/scripts/ng-eid.js',
     'bower_components/angular-mocks/angular-mocks.js',
     // endbower
       'app/scripts/**/*.module.js',


### PR DESCRIPTION
https://test1.ampath.or.ke:8443/test-builds/AA-656/

Note that you won't be able to fetch data due to https browser security policy of mixed content: The reason eid endpoints are none https (http://eid.ampath.or.ke:85/eid/ and http://41.79.169.130:85/eid/) so you will get this error:

Mixed Content: The page at 'https://test1.ampath.or.ke:8443/test-builds/AA-656/#/patientsearch' was loaded over HTTPS, but requested an insecure XMLHttpRequest endpoint 'http://eid.ampath.or.ke:85/eid/orders/api.php?apikey=35243eba2&currentpage=0&patientID=&test=2'. This request has been blocked; the content must be served over HTTPS

To test this run it locally 
